### PR TITLE
feat(button): add optional Widget slot for icon or another widget

### DIFF
--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.0
+
+_Feat_
+
+- Add optional icon button attribute to use another Widget than the default Text.
+  If this attribute is null, the default Text is used.
+
 ## 0.6.0
 
 _Chore_

--- a/flutter/lib/button.dart
+++ b/flutter/lib/button.dart
@@ -10,6 +10,7 @@ class Button extends StatefulWidget {
     this.fontColor = kTextColor,
     this.buttonHeight,
     this.defaultPressed = false,
+    this.icon,
   });
 
   factory Button.secondary({
@@ -18,6 +19,7 @@ class Button extends StatefulWidget {
     VoidCallback? onPressed,
     double? buttonHeight,
     bool defaultPressed = false,
+    Widget? icon,
   }) {
     return Button(
       key: key,
@@ -26,6 +28,7 @@ class Button extends StatefulWidget {
       color: kSecondaryColor,
       buttonHeight: buttonHeight,
       defaultPressed: defaultPressed,
+      icon: icon,
     );
   }
 
@@ -35,6 +38,7 @@ class Button extends StatefulWidget {
     VoidCallback? onPressed,
     double? buttonHeight,
     bool defaultPressed = false,
+    Widget? icon,
   }) {
     return Button(
       key: key,
@@ -44,6 +48,7 @@ class Button extends StatefulWidget {
       fontColor: kSecondaryTextColor,
       buttonHeight: buttonHeight,
       defaultPressed: defaultPressed,
+      icon: icon,
     );
   }
 
@@ -53,6 +58,7 @@ class Button extends StatefulWidget {
   final double? buttonHeight;
   final VoidCallback? onPressed;
   final bool defaultPressed;
+  final Widget? icon;
 
   @override
   State<Button> createState() => _ButtonState();
@@ -109,18 +115,18 @@ class _ButtonState extends State<Button> {
             ),
           ),
           child: Center(
-            child: Text(
-              widget.text,
-              style: TextStyle(
-                color: widget.onPressed != null
-                    ? widget.fontColor
-                    : Colors.black.withOpacity(0.15),
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                fontFamily: 'SF Pro Rounded',
-              ),
-            ),
-          ),
+              child: widget.icon ??
+                  Text(
+                    widget.text,
+                    style: TextStyle(
+                      color: widget.onPressed != null
+                          ? widget.fontColor
+                          : Colors.black.withOpacity(0.15),
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      fontFamily: 'SF Pro Rounded',
+                    ),
+                  )),
         ),
       ),
     );

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yaki_ui
 description: Yaki UI is a Flutter UI library for building beautiful apps.
-version: 0.6.0
+version: 0.7.0
 homepage: https://xpeho.com
 
 environment:


### PR DESCRIPTION
Allow to use an icon or widget different than a Text(), will be show if the "icon" attribut is not null, otherwise will use the default Text value