### PR TITLE
fix(font-weight): remove bold for the entier container class

### DIFF
--- a/web/css/components/modal.css
+++ b/web/css/components/modal.css
@@ -58,7 +58,6 @@
   width: 340px;
 
   & span {
-    font-weight: bold;
     font-size: 18px;
     color: #303134;
   }


### PR DESCRIPTION
# New change proposal

Thank you for contributing to yaki_ui.

<!-- Please first describe your change. -->

# Change category

- [ ] Feature
- [x] Fix
- [ ] Documentation
- [ ] Chore

# Description

<!-- Put a full  description of your modifications -->

# Screenshots (if any)

<!-- Add screens to show your changes -->

# Checklist

- [ ] I have tested my changes
- [ ] The golden tests scenarios has been updated
- [ ] The golden files has been refreshed
- [ ] The previous tests still works
- [ ] I did not broke anything to ensure reverse compatibility
- [ ] root README updated
- [ ] platforms README updated (Flutter, web, Jetpack Compose, SwiftUI)
- [ ] CHANGELOG updated
- [ ] version updated
